### PR TITLE
fix: Resolve asyncio loop mismatch error

### DIFF
--- a/chzzk/__init__.py
+++ b/chzzk/__init__.py
@@ -3,7 +3,7 @@ __title__ = 'chzzk'
 __author__ = 'westreed'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2024-present westreed'
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 from typing import NamedTuple, Literal
 from .chzzk import Chzzk
@@ -18,6 +18,6 @@ class VersionInfo(NamedTuple):
     serial: int
 
 
-version_info: VersionInfo = VersionInfo(major=0, minor=1, micro=1, releaselevel='alpha', serial=0)
+version_info: VersionInfo = VersionInfo(major=0, minor=1, micro=2, releaselevel='alpha', serial=0)
 
 del NamedTuple, Literal, VersionInfo

--- a/chzzk/event/event_manager.py
+++ b/chzzk/event/event_manager.py
@@ -10,7 +10,7 @@ _log = logging.getLogger(__name__)
 
 class EventManager:
     def __init__(self, prefix: str, loop: Optional[asyncio.AbstractEventLoop] = None):
-        self.loop: asyncio.AbstractEventLoop = loop or asyncio.get_event_loop()
+        self.loop: Optional[asyncio.AbstractEventLoop] = loop
         self.prefix = prefix
         self._listeners: dict[str, list[tuple[asyncio.Future, Callable[..., bool]]]] = dict()
         self._extra_event: dict[str, list[Callable[..., Coroutine[Any, Any, Any]]]] = dict()
@@ -48,6 +48,7 @@ class EventManager:
             The number of seconds to wait before timing out and raising
             :exc:`asyncio.TimeoutError`.
         """
+        assert self.loop is not None, "Asyncio Loop is None."
         future = self.loop.create_future()
 
         if check is None:
@@ -183,6 +184,7 @@ class EventManager:
             *args: Any,
             **kwargs: Any,
     ) -> asyncio.Task:
+        assert self.loop is not None, "Asyncio Loop is None."
         wrapped = self._run_event(coro, event_name, *args, **kwargs)
         # Schedules the task
         return self.loop.create_task(wrapped, name=f"chzzk: {event_name}")


### PR DESCRIPTION
## Loop 불일치 문제

1. 타입힌트에 맞춰 개선하는 과정에서 EventManager에서 loop가 None인 경우, 생성자에서 asyncio.get_event_loop()로 loop를 얻어오게 만듬.
2. 하지만 일반 사용자는 ChzzkChat 클라이언트를 먼저 선언되고, 그 이후 asyncio.run을 통해 함수가 실행됨.
3. 서로 다른 loop가 되어 dispatch 함수가 실행되지 않음.
4. asyncio.run하는 과정에서 loop를 얻어와서 실행하도록 변경하여 문제 해결.